### PR TITLE
fix: replace `any` type with proper typing in CountryMap

### DIFF
--- a/src/components/ecommerce/CountryMap.tsx
+++ b/src/components/ecommerce/CountryMap.tsx
@@ -16,7 +16,7 @@ const CountryMap: React.FC<CountryMapProps> = ({ mapColor }) => {
         initial: {
           fill: "#465FFF",
           r: 4, // Custom radius for markers
-        } as any, // Type assertion to bypass strict CSS property checks
+        } as { fill: string; r: number },
       }}
       markersSelectable={true}
       markers={[


### PR DESCRIPTION
## Summary
This PR fixes a TypeScript linting issue in `CountryMap.tsx`.

## Problem
Previously, the `markerStyle.initial` object was type-cast as `any`:
```ts
initial: {
  fill: "#465FFF",
  r: 4,
} as any
This caused the following error in VSCode:

Unexpected any. Specify a different type. (eslint@typescript-eslint/no-explicit-any)

Solution:
Replaced the any type assertion with a more specific type:
  } as { fill: string; r: number }
This removes the linting error while preserving correct typing.

Testing:
Verified project builds without TypeScript errors

Verified CountryMap renders as expected with custom marker styling
